### PR TITLE
Update fiftyone/utils/coco.py to fix bug #1629

### DIFF
--- a/fiftyone/utils/coco.py
+++ b/fiftyone/utils/coco.py
@@ -1270,7 +1270,10 @@ def load_coco_detection_annotations(json_path, extra_attrs=True):
 
 def _parse_coco_detection_annotations(d, extra_attrs=True):
     # Load info
-    info = d.get("info", {})
+     info = {}
+        if d.get("info", {}) is not None
+            info.update(d.get("info", {}))
+            
     licenses = d.get("licenses", None)
     categories = d.get("categories", None)
     if licenses is not None:


### PR DESCRIPTION
## What changes are proposed in this pull request?

Redefined "info" variable initialization in line 1273 _parse_coco_detection_annotations definition so that it will always be a dictionary type even if info in the annotation json file is defined as null, NoneType, or anything other than DictType.

This avoids value assignment issues with line 1280 or 1283 in coco.py

## How is this patch tested? If it is not, please explain why.

Tested on Objects365 object detection database, which in it annotation json files defines:
```
"info":  null,
```
## Release Notes

Bug Fix [#1629]

### Is this a user-facing change that should be mentioned in the release notes?

<!--
Please fill in relevant options below with an "x", or by clicking the checkboxes
after submitting this pull request. Example:
-   [x] Selected option
-->

-   [x ] No. You can skip the rest of this section.
-   [ ] Yes. Give a description of this change to be included in the release
        notes for FiftyOne users.

(Details in 1-2 sentences. You can just refer to another PR with a description
if this PR is part of a larger change.)

### What areas of FiftyOne does this PR affect?
voxel51/fiftyone/fiftyone/utils/coco.py

-   [ ] App: FiftyOne application changes
-   [ ] Build: Build and test infrastructure changes
-   [x] Core: Core `fiftyone` Python library changes
-   [ ] Documentation: FiftyOne documentation changes
-   [ ] Other
